### PR TITLE
Add extra information for npm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ npm run dev                # Run the development server
 npm run build              # Build the entire site
 ```
 
+This `npm` needs to be version 10.22.0, so you first have to make sure that you're entering these commands with that
+version. To do that, in your bash terminal, enter the following to install that version and use it:
+
+```bash
+nvm install 10.22.0
+```
+
 ## Setup for and Use of Binder
 
 The [`requirements.txt`](binder/requirements.txt) in the repository defines the


### PR DESCRIPTION
This leaves some clarifying information with regard to the notion that when the dependencies are installed, they have to be installed with v10.22.0 as specified in the .nvmrc file